### PR TITLE
Ignore master branch on validate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,8 @@
 name: Validate
-on: [push]
+on:
+ push:
+   branches-ignore:
+   - master
 
 jobs:
   validate:


### PR DESCRIPTION
- At this point, the project has already been validated, so I don't need to do it again.